### PR TITLE
Update the optimistic park spin to use a deterministic approach

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -2198,11 +2198,13 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
             if (spins > 0) {
                 ThreadLocalRandom tl = ThreadLocalRandom.current();
                 do {
-                    if (tl.nextInt(PARK_SPINS) < YIELD_FACTOR) {
-                        Thread.yield();
-                    }
                     if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
                         return;
+                    }
+                    if (tl.nextInt(PARK_SPINS) < YIELD_FACTOR) {
+                        Thread.yield();
+                    } else {
+                        JDKSpecific.onSpinWait();
                     }
                     spins--;
                 } while (spins > 0);
@@ -2226,11 +2228,13 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                 //overruns a bit (as the nano time is for thread timeout) we just spin then check
                 //to keep performance consistent between the two versions.
                 do {
-                    if (tl.nextInt(PARK_SPINS) < YIELD_FACTOR) {
-                        Thread.yield();
-                    }
                     if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
                         return;
+                    }
+                    if (tl.nextInt(PARK_SPINS) < YIELD_FACTOR) {
+                        Thread.yield();
+                    } else {
+                        JDKSpecific.onSpinWait();
                     }
                     spins--;
                 } while (spins > 0);

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -2206,20 +2206,18 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
         }
 
         void park(EnhancedQueueExecutor enhancedQueueExecutor) {
-            int spins = PARK_SPINS;
-            if (spins > 0) {
-                ThreadLocalRandom tl = ThreadLocalRandom.current();
-                do {
-                    if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
-                        return;
-                    }
-                    if (tl.nextInt(PARK_SPINS) < YIELD_FACTOR) {
+            if (PARK_SPINS > 0) {
+                if (optimisticSpin()) {
+                    return;
+                }
+                if (YIELD_FACTOR > 0) {
+                    for (int spins = 0; spins < YIELD_FACTOR; spins++) {
                         Thread.yield();
-                    } else {
-                        JDKSpecific.onSpinWait();
+                        if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
+                            return;
+                        }
                     }
-                    spins--;
-                } while (spins > 0);
+                }
             }
             try {
                 if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_NORMAL, STATE_PARKED)) {
@@ -2229,33 +2227,27 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                 unsafe.compareAndSwapInt(this, parkedOffset, STATE_PARKED, STATE_NORMAL);
             }
         }
+
         void park(EnhancedQueueExecutor enhancedQueueExecutor, long nanos) {
-            long remaining;
-            int spins = PARK_SPINS;
-            if (spins > 0) {
-                long start = System.nanoTime();
-                ThreadLocalRandom tl = ThreadLocalRandom.current();
-                //note that we don't check the nanotime while spinning
-                //as spin time is short and for our use cases it does not matter if the time
-                //overruns a bit (as the nano time is for thread timeout) we just spin then check
-                //to keep performance consistent between the two versions.
-                do {
-                    if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
-                        return;
-                    }
-                    if (tl.nextInt(PARK_SPINS) < YIELD_FACTOR) {
-                        Thread.yield();
-                    } else {
-                        JDKSpecific.onSpinWait();
-                    }
-                    spins--;
-                } while (spins > 0);
-                remaining = nanos - (System.nanoTime() - start);
-                if (remaining < 0) {
+            //note that we don't check the nanotime while spinning
+            //as spin time is short and for our use cases it does not matter if the time
+            //overruns a bit (as the nano time is for thread timeout) we just spin then check
+            //to keep performance consistent between the two versions.
+            long remaining = nanos;
+            if (PARK_SPINS > 0) {
+                if (optimisticSpin()) {
                     return;
                 }
-            } else {
-                remaining = nanos;
+                if (YIELD_FACTOR > 0) {
+                    long start = System.nanoTime();
+                    for (int spins = 0; spins < YIELD_FACTOR; spins++) {
+                        Thread.yield();
+                        if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
+                            return;
+                        }
+                    }
+                    remaining -= (System.nanoTime() - start);
+                }
             }
             try {
                 if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_NORMAL, STATE_PARKED)) {
@@ -2264,6 +2256,22 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
             } finally {
                 unsafe.compareAndSwapInt(this, parkedOffset, STATE_PARKED, STATE_NORMAL);
             }
+        }
+
+        /** Returns true if this operation was successful and a park operation is unnecessary. */
+        boolean optimisticSpin() {
+            // Always begin with an optimistic check to allow the loop (either onSpinWait or yield)
+            // to wait before a comparison.
+            if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
+                return true;
+            }
+            for (int spins = 0, limit = PARK_SPINS - YIELD_FACTOR; spins < limit; spins++) {
+                JDKSpecific.onSpinWait();
+                if (unsafe.compareAndSwapInt(this, parkedOffset, STATE_UNPARKED, STATE_NORMAL)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         void unpark() {

--- a/src/main/java/org/jboss/threads/JDKSpecific.java
+++ b/src/main/java/org/jboss/threads/JDKSpecific.java
@@ -40,4 +40,8 @@ final class JDKSpecific {
             default: throw Assert.impossibleSwitchCase(timeUnit);
         }
     }
+
+    static void onSpinWait() {
+        // no operation
+    }
 }

--- a/src/main/java9/org/jboss/threads/JDKSpecific.java
+++ b/src/main/java9/org/jboss/threads/JDKSpecific.java
@@ -28,4 +28,8 @@ final class JDKSpecific {
     static TemporalUnit timeToTemporal(final TimeUnit timeUnit) {
         return timeUnit.toChronoUnit();
     }
+
+    static void onSpinWait() {
+        Thread.onSpinWait();
+    }
 }


### PR DESCRIPTION
This algorithm first spins, escalates to yield, then parks after
a fixed number of iterations. This change updates the edge conditions
to avoid cases where we yield without attempting cas operation
afterward.